### PR TITLE
feat: extend emojiMap and event color logic

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2,6 +2,7 @@
 const emojiMap = {
   'interview': '🎙️',
   'flight': '🛫',
+  'bus': '🚌',
   'journey': '🚆',
   'trip': '🚆',
   'stay': '🏠',
@@ -68,7 +69,7 @@ function ColorEvents() {
       if (originalTitle.includes("interview")) {
         color = CalendarApp.EventColor.YELLOW;
         Logger.log("Title: " + title + " - Color to print: YELLOW");
-      } else if (originalTitle.includes("flight") || originalTitle.includes("journey") || originalTitle.includes("trip")) {
+      } else if (originalTitle.includes("flight") || originalTitle.includes("journey") || originalTitle.includes("trip") || originalTitle.includes("bus")) {
         color = CalendarApp.EventColor.ORANGE;
         Logger.log("Title: " + title + " - Color to print: ORANGE");
       } else if (originalTitle.includes("stay") || originalTitle.includes("reservation")) {

--- a/Code.js
+++ b/Code.js
@@ -11,6 +11,8 @@ const emojiMap = {
   'meeting': '🤝',
   'catch-up': '☕',
   'video call': '📹',
+  'call': '📞',
+  'ara': '📞',
   'sosyal aktivite': '🎉',
   'paris 2024': '🏅',
   'randevu': '📅',
@@ -65,7 +67,6 @@ function ColorEvents() {
         }
       }
 
-      // Set colors (commented out for now)
       if (originalTitle.includes("interview")) {
         color = CalendarApp.EventColor.YELLOW;
         Logger.log("Title: " + title + " - Color to print: YELLOW");
@@ -78,7 +79,7 @@ function ColorEvents() {
       } else if (originalTitle.includes("holy shred") || originalTitle.includes("holy ride")) {
         color = CalendarApp.EventColor.RED;
         Logger.log("Title: " + title + " - Color to print: RED");
-      } else if (originalTitle.startsWith("🤝 Meeting") || originalTitle.includes("catch-up")) {
+      } else if (originalTitle.startsWith("🤝 Meeting") || originalTitle.includes("catch-up") || originalTitle.includes("video call") || originalTitle.includes("call") || originalTitle.includes("ara")) {
         color = CalendarApp.EventColor.MAUVE;
         Logger.log("Title: " + title + " - Color to print: MAUVE");
       } else if (originalTitle.includes("sosyal aktivite")) {


### PR DESCRIPTION
## Summary
This pull request extends the `emojiMap` and updates the event color logic in the `ColorEvents` function to handle additional event types.

## Changes
- Added new entries to the `emojiMap`:
  - `bus`: 🚌
  - `call`: 📞
  - `ara`: 📞
- Updated the event color logic in `ColorEvents`:
  - Added `bus` to the list of events that get the ORANGE color.
  - Added `video call`, `call`, and `ara` to the list of events that get the MAUVE color.

## Additional Notes
- The new emoji entries ensure that events with titles containing \`bus\`, \`call\`, or \`ara\` are properly mapped to their respective emojis.
- The color logic now includes these new event types, ensuring consistent color coding for calendar events.