### PR TITLE
feat: add emoji and color mapping for gas and electricity events

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -21,6 +21,7 @@ const emojiMap = {
   'tamir': '🛠️',
   'repair': '🛠️',
   'payment': '💸',
+  'gas and electricity': '🔌',
 };
 
 function ColorEvents() {
@@ -88,7 +89,7 @@ function ColorEvents() {
       } else if (originalTitle.includes("paris 2024")) {
         color = CalendarApp.EventColor.BLUE;
         Logger.log("Title: " + title + " - Color to print: BLUE");
-      } else if (originalTitle.includes("randevu") || originalTitle.includes("appointment")) {
+      } else if (originalTitle.includes("randevu") || originalTitle.includes("appointment") || originalTitle.includes("gas and electricity")) {
         color = CalendarApp.EventColor.GRAY;
         Logger.log("Title: " + title + " - Color to print: GRAY");
       }


### PR DESCRIPTION
## Summary
This pull request adds support for 'gas and electricity' events by mapping them to an emoji and setting their color in the calendar.

## Changes
- Added 'gas and electricity' to `emojiMap` with the emoji '🔌'.
- Updated `ColorEvents` function to include 'gas and electricity' in the condition for setting event color to gray.

## Additional Notes
- Ensure that the event titles containing 'gas and electricity' are correctly formatted to trigger the new color and emoji mappings.
- No additional dependencies were introduced with this change.